### PR TITLE
Update ambient_sound.py

### DIFF
--- a/ambient_sound.py
+++ b/ambient_sound.py
@@ -274,8 +274,9 @@ class Ambient_sound(NeuronModule):
         """
         Clean up all data stored in the pid.txt file
         """
+        absolute_pid_file_path = SoundDatabase.get_neuron_path() + os.sep + pid_file_path
         try:
-            with open(pid_file_path, "w") as file_open:
+            with open(absolute_pid_file_path, "w") as file_open:
                 file_open.close()
                 logger.debug("[Ambient_sounds] pid file cleaned")
 


### PR DESCRIPTION
Hello :)

For information (minor thing), in the ambient_sound neuron, the modification of the pid.txt file works only if we use the absolute path of the file. This absolute path is used everywhere except in clean_pid_file() function. It doesn't matter for the operation but it lets the last used pid in the file.

It just need to change the 277 and 278 lines:
```
        try:
            with open(pid_file_path, "w") as file_open:
```
with
```
        absolute_pid_file_path = SoundDatabase.get_neuron_path() + os.sep + pid_file_path
        try:
            with open(absolute_pid_file_path, "w") as file_open:
```